### PR TITLE
Fix bookmark feature

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
 
   "manifest_version": 2,
   "name": "LinkDump",
-  "version": "1.8",
+  "version": "1.9",
   "description": "__MSG_extensionDescription__",
   "icons": {
     "48": "icons/linkdump-48.png"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "linkdump",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkdump",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Store links and dump them",
   "main": "background.js",
   "scripts": {


### PR DESCRIPTION
Before, when adding a folder of bookmarks, not all bookmarks
weren't added to the dump due to the local storage interractions.
There was many concurrent calls to the local storage and they all
wrote what they know at the time they were accessing it. Thus we
add data loss.
Now the process is rewritten to make a single call with all links
needed to be dumped.