### PR TITLE
Add a link capture feature

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -7,6 +7,10 @@
     "message": "Add to dump",
     "description": "Add to dump entry in menus."
   },
+  "menuCaptureLink": {
+    "message": "Capture links",
+    "description": "Capture links to store them in the dump."
+  },
   "notificationDownloadComplete": {
     "message": "Download complete",
     "description": "Notify the user that the download is complete."
@@ -42,5 +46,9 @@
   "popupContentEmpty": {
     "message": "The dump is empty!",
     "description": "Default content when there is no link in the dump."
+  },
+  "warningLinkCapture": {
+    "message": "Stop link capture.",
+    "description": "Warning displayed when activing the link capture feature."
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -7,6 +7,10 @@
     "message": "Entreposer",
     "description": "Add to dump entry in menus."
   },
+  "menuCaptureLink": {
+    "message": "Intercepter les liens",
+    "description": "Capture links to store them in the dump."
+  },
   "notificationDownloadComplete": {
     "message": "Téléchargement terminé",
     "description": "Notify the user that the download is complete."
@@ -42,5 +46,9 @@
   "popupContentEmpty": {
     "message": "L'entrepôt est vide !",
     "description": "Default content when there is no link in the dump."
+  },
+  "warningLinkCapture": {
+    "message": "Arrêter l'interception des liens.",
+    "description": "Warning displayed when activing the link capture feature."
   }
 }

--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 const linkAddId = 'link-add';
 const bookmarkAddId = 'bookmark-add';
+const captureLinkId = 'capture-link';
 const textReducer = (carry, item) => `${carry + item.url}\n`;
 const markdownReducer = (carry, item) =>
   `${carry}[${item.title}](${item.url})\n`;
@@ -220,6 +221,9 @@ function handleMessage(message) {
     case 'clear':
       clear();
       break;
+    case 'addLink':
+      addLink(message.payload);
+      break;
     default:
     // Do nothing on purpose
   }
@@ -237,6 +241,12 @@ browser.menus.create({
   contexts: ['bookmark']
 });
 
+browser.menus.create({
+  id: captureLinkId,
+  title: browser.i18n.getMessage('menuCaptureLink'),
+  contexts: ['page']
+});
+
 browser.menus.onClicked.addListener(info => {
   switch (info.menuItemId) {
     case linkAddId:
@@ -248,6 +258,14 @@ browser.menus.onClicked.addListener(info => {
       break;
     case bookmarkAddId:
       addBookmark(info.bookmarkId);
+      break;
+    case captureLinkId:
+      browser.tabs.executeScript({
+        file: "/content/content.js"
+      });
+      browser.tabs.insertCSS({
+        file: "/content/content.css"
+      });
       break;
     default:
     // Do nothing on purpose

--- a/content/content.css
+++ b/content/content.css
@@ -1,0 +1,17 @@
+:root {
+    --active-color: #007bc5;
+}
+.linkdump {
+    background-color: white;
+    background-image:  url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAA7AAAAOwBeShxvQAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAJzSURBVFiFtZfPa1NBEMc/VrHRs5BiSVGboKAebGzTP6N/gXgpCOLZX1QFTwV70pNIwb/BU8FL1dR6UBQ18Q9oG7z0kjamBY2Hmacv29mXfXmvA8sjO/Od72R3dmYX8pMJ4B5QB1rAvn7rOj+RI1efjAJLQBfoJYyu2hXyJC8C7wcQu2NdcbmQf0tJHo2PwIks5GNAc0jyaDw5DPJd4D5wDhgBzgILOu/a/gJKeZJvAzMe3CzQMTB305CfBD4lkFcH4B8YuDdpAniZgRygbGBboeRXgD8ZyEGy3sXvhQawbIDbMfJJ4BkwneDjguFjK4R8BPhpgOdVXwY2dK4DzHn8PDZ8rIYEUDSAO0gJPgp8cXS7wJTjo4YcO9fPHYtwDHgF3NLflw3gV9VVDF0PaGhwAOeRXHFtOsC4Rd5Qg6bOnTHAm6orIN3OCuKa2sx79IsueZH+ItMGjijJnuHgaiyID4Z+RfWXDN0asoX/ZBS7q11U/WtDt87/1jpj6LvAcf0TO7H5JkY3XPIsU5Tp1z36eiyILUMfXUKilW0g29wnJezLxDaSQADH8PeAitp8T1jBm0hiHyAHuS5ZGVpz7KocbCifkWwvYHe8UxahK+8M4COP7VwsiA2kCAHcMHxsIvs/UFoGuJJgPw08RcovyMq0DR/PQ8jBPmKhF8cqdpH5jRSwILFWYDIRkUzeA16EkoOdAwsZyFNfOH2nYNZjX0sgb+I5akniqwMd5BpVRipaGXiI3dWGJo/EVwlDRyZykKxP+8KJxg/gdBbySIZ5Zq2R0zMrkgLyYvHtczw/FnFaap5SQh4Nb5Eut6/fVeA2xk1mWPkLtFu4uY7vL30AAAAASUVORK5CYII=');
+    background-repeat: no-repeat;
+    background-position: 0.5em center;
+    padding: 1em 0.5em;
+    padding-left: calc(1em + 32px);
+    border: 2px solid var(--active-color);
+    border-radius: 5px;
+    position: fixed;
+    top: 2em;
+    left: 2em;
+    z-index: 99999999;
+}

--- a/content/content.js
+++ b/content/content.js
@@ -1,0 +1,22 @@
+function sendMessage(event) {
+    const link = event.target.closest('a');
+    if (link !== null) {
+        browser.runtime.sendMessage({
+            action: 'addLink',
+            payload: { url: link.href, title: link.text.trim() }
+        });
+        event.preventDefault();
+        event.stopPropagation();
+    }
+}
+
+let divElement = document.createElement('div');
+divElement.className = 'linkdump';
+divElement.innerText = browser.i18n.getMessage(`warningLinkCapture`);
+divElement.addEventListener('click', (event) => {
+    document.documentElement.removeEventListener('click', sendMessage, true);
+    divElement.remove();
+});
+document.body.appendChild(divElement);
+
+document.documentElement.addEventListener('click', sendMessage, true);


### PR DESCRIPTION
It is not possible to enable the link capture feature on any page.
This will allow to redirect links to the dump instead of opening
them. Thus limiting the number of click action needed on a page
with multiple links to dump.